### PR TITLE
Declare renderer as extern; fix #13

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -14,7 +14,7 @@
 
 // SDL2 renderer. Needs to be declared here because several different units access to it
 // directly to draw on it because there's no discrete graphics unit, but it works, so no complains :D
-SDL_Renderer *renderer;
+extern SDL_Renderer *renderer;
 
 // Default layout to PSX gamepad with USB adapter
 #define JUMP_JOYBUTTON 2

--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,7 @@
 
  
 #include "main.h"
-
+SDL_Renderer *renderer;
 int main (int argc, char** argv) {
 
 	// TODO: support arguments for fullscreen, etc.


### PR DESCRIPTION
With gcc 10 the linking fails because `renderer` is defined multiple times.
Adding the `extern` keyword makes sure that the header only declares the variable without defining it.
A definition for the variable is added in main.c

Fixes #13.