### PR TITLE
Add platform: Rpi4 in aarch64 mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ CFLAGS=		-O2 -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard
 DATADIR= "\"./\""
 endif
 
+ifeq ($(PLATFORM), rpi4_64)
+CFLAGS=		-O2 -march=armv8-a+crc+simd -mtune=cortex-a72
+DATADIR= "\"./\""
+endif
+
 DATADIR?="\"$(PREFIX)/share/abbayev2\""
 LDFLAGS?=	-Wl,-z,relro
 

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,7 @@ int main (int argc, char** argv) {
 			SDL_WINDOWPOS_CENTERED,SDL_WINDOWPOS_CENTERED,768,576,0);
 
 	/* Create renderer (with VSync, nice !) */
-	SDL_SetHint("SDL_HINT_RENDER_SCALE_QUALITY", "linear");
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
 	renderer = SDL_CreateRenderer(screen, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
 	SDL_RenderSetLogicalSize(renderer, 256, 192);
 	SDL_SetRenderDrawColor(renderer,0,0,0,255);


### PR DESCRIPTION
Added platform support for Pi4 in aarch64 mode, since Raspberry Pi OS 64bit is the future of the Pi platform.