### PR TITLE
Add Mac support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,7 @@ ifneq ($(PLATFORM), mac)
 LDFLAGS?=      -Wl,-z,relro
 endif
 
-ifeq ($(PLATFORM), mac)
-CFLAGS+=	-I/opt/homebrew/include -D_THREAD_SAFE -DDATADIR=$(DATADIR)
-else
-CFLAGS+=	`sdl2-config --config` -DDATADIR=$(DATADIR)
-endif
+CFLAGS+=	`sdl2-config --cflags` -DDATADIR=$(DATADIR)
 LIBS=		`sdl2-config --libs` -lSDL2_image -lSDL2_mixer -lm
 
 PROG=		abbayev2

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -33,6 +33,16 @@ Under GNU/Linux and FreeBSD, in order to compile this program, you need to
 install SDL2, SDL2_image and SDL2_mixer libraries. Check your distribution
 instructions on how to install them.
 
+For example, on Fedora:
+
+    sudo dnf install SDL2-devel SDL2_image-devel SDL2_mixer-devel
+
+And on Debian:
+
+    sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev
+
+Now we can proceed to the main build:
+
     tar xf abbaye-<version>.tar.gz # unpack the source code file (or download from Github)
     cd abbaye-<version>            # enter the directory
     make                           # build the game executable
@@ -43,7 +53,7 @@ Alternatively you can run the game with `abbayev2`.
 
 ### Mac installation
 
-To build on Macs, we use Homebrew as the package manager for dependencies.
+To build on Macs, we use Homebrew as the package manager for dependencies. Note that we must specify `PLATFORM=mac` to the make commands
 
     brew install SDL2 SDL2_image SDL2_mixer
     tar xf abbaye-<version>.tar.gz # unpack the source code file (or download from Github)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,6 +16,7 @@ Currently, this port works on:
 
  * GNU/Linux (32 & 64 bits), including Raspberry Pi
  * FreeBSD
+ * Mac (must specify PLATFORM=mac to make commands)
  * OpenPandora
  * CGW Zero
  * Nintendo Wii
@@ -32,13 +33,24 @@ Under GNU/Linux and FreeBSD, in order to compile this program, you need to
 install SDL2, SDL2_image and SDL2_mixer libraries. Check your distribution
 instructions on how to install them.
 
-    tar xf abbaye-<version>.tar.gz # unpack the source code file
+    tar xf abbaye-<version>.tar.gz # unpack the source code file (or download from Github)
     cd abbaye-<version>            # enter the directory
     make                           # build the game executable
     make install                   # install the game (as root)
 
 An icon will appear in your application menu, in game section.
 Alternatively you can run the game with `abbayev2`.
+
+### Mac installation
+
+To build on Macs, we use Homebrew as the package manager for dependencies.
+
+    brew install SDL2 SDL2_image SDL2_mixer
+    tar xf abbaye-<version>.tar.gz # unpack the source code file (or download from Github)
+    cd abbaye-<version>            # enter the directory
+    make PLATFORM=mac              # build the game executable
+    sudo make install PLATFORM=mac # install the game (as root)
+
 
 ## Uninstallation from source
 

--- a/src/base.h
+++ b/src/base.h
@@ -7,9 +7,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
-#include <SDL2/SDL_mixer.h>
+#include <SDL.h>
+#include <SDL_image.h>
+#include <SDL_mixer.h>
 
 #define uint unsigned int
 


### PR DESCRIPTION
This patch adds Mac support (via Homebrow), and also fixes a small quirk of the current build where it will build on Ubuntu / Debian derivatives but not necessarily on other Linux variants - e.g. current HEAD does not build OOTB on Fedora, and I'd be surprised if it still builds on FreeBSD either.

Changes tested on:

* Mac 15.5
* Fedora 41
* RPi 5 (Bookworm)